### PR TITLE
Upgrade golangci to v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
             -   uses: "actions/setup-go@v5"
                 with:
                     go-version-file: go.mod
-            -   uses: "golangci/golangci-lint-action@v6"
+            -   uses: "golangci/golangci-lint-action@v7"
                 with:
                     version: "latest"
     

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,51 +1,53 @@
----
+version: "2"
 run:
-    go: "1.23"
-    timeout: "5m"
-output:
-    sort-results: true
-linters-settings:
-    goimports:
-        local-prefixes: "sot-te.ch/mochi"
-    staticcheck:
-        checks:
-            - "all"
-    gosec:
-        excludes:
-            - "G505"  # Allow SHA1 usage
-            - "G115" # FIXME: remove after https://github.com/securego/gosec/issues/1187 resolve
+  go: "1.23"
 linters:
-    enable:
-        - "bidichk"
-        - "bodyclose"
-        - "errcheck"
-        - "errname"
-        - "errorlint"
-        - "gofumpt"
-        - "goimports"
-        - "goprintffuncname"
-        - "gosec"
-        - "gosimple"
-        - "govet"
-        - "importas"
-        - "ineffassign"
-        - "makezero"
-        - "prealloc"
-        - "predeclared"
-        - "revive"
-        - "rowserrcheck"
-        - "staticcheck"
-        - "stylecheck"
-        - "tenv"
-        - "typecheck"
-        - "unconvert"
-        - "unused"
-        - "wastedassign"
-        - "whitespace"
-issues:
-    include:
-        - "EXC0012"  # Exported should have comment
-        - "EXC0012"  # Exported should have comment
-        - "EXC0013"  # Package comment should be of form
-        - "EXC0014"  # Comment on exported should be of form
-        - "EXC0015"  # Should have a package comment
+  enable:
+    - bidichk
+    - bodyclose
+    - errname
+    - errorlint
+    - goprintffuncname
+    - gosec
+    - importas
+    - makezero
+    - prealloc
+    - predeclared
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - unconvert
+    - wastedassign
+    - whitespace
+  settings:
+    gosec:
+      excludes:
+        - G505
+        - G115
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - sot-te.ch/mochi
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/bittorrent/request.go
+++ b/bittorrent/request.go
@@ -20,7 +20,7 @@ var globalBroadcastIPv4 = netip.AddrFrom4([4]byte{255, 255, 255, 255})
 
 // IsValid checks if netip.Addr is valid, not unspecified and not multicast
 func (a RequestAddress) IsValid() bool {
-	return a.Addr.IsValid() && !(a.IsUnspecified() || a.IsMulticast() || a.Addr == globalBroadcastIPv4)
+	return a.Addr.IsValid() && !a.IsUnspecified() && !a.IsMulticast() && a.Addr != globalBroadcastIPv4
 }
 
 // MarshalZerologObject writes fields into zerolog event

--- a/frontend/http/frontend.go
+++ b/frontend/http/frontend.go
@@ -117,7 +117,7 @@ func (cfg Config) Validate() (validCfg Config, err error) {
 			Strs("default", validCfg.ScrapeRoutes).
 			Msg("falling back to default configuration")
 	}
-	validCfg.ParseOptions.ParseOptions = cfg.ParseOptions.ParseOptions.Validate(logger)
+	validCfg.ParseOptions.ParseOptions = cfg.ParseOptions.Validate(logger)
 	return
 }
 
@@ -163,7 +163,7 @@ func NewFrontend(c conf.MapConfig, logic *middleware.Logic) (frontend.Frontend, 
 			return nil, err
 		}
 		certs := []tls.Certificate{cert}
-		f.Server.TLSConfig = &tls.Config{
+		f.TLSConfig = &tls.Config{
 			Certificates: certs,
 			MinVersion:   tls.VersionTLS12,
 		}
@@ -194,7 +194,7 @@ func NewFrontend(c conf.MapConfig, logic *middleware.Logic) (frontend.Frontend, 
 		pathRouting[path.Clean(route)] = f.ping
 	}
 
-	f.Server.Handler = func(ctx *fasthttp.RequestCtx) {
+	f.Handler = func(ctx *fasthttp.RequestCtx) {
 		if route, exists := pathRouting[string(ctx.Path())]; exists {
 			route(ctx)
 		} else {
@@ -228,7 +228,7 @@ func runServer(s *fasthttp.Server, cfg *Config) {
 func (f *httpFE) Close() (err error) {
 	f.onceCloser.Do(func() {
 		if f.Server != nil {
-			err = f.Server.Shutdown()
+			err = f.Shutdown()
 		}
 	})
 

--- a/frontend/http/params.go
+++ b/frontend/http/params.go
@@ -2,9 +2,10 @@ package http
 
 import (
 	"github.com/rs/zerolog"
+	"github.com/valyala/fasthttp"
+
 	"github.com/sot-tech/mochi/bittorrent"
 	"github.com/sot-tech/mochi/pkg/str2bytes"
-	"github.com/valyala/fasthttp"
 )
 
 // queryParams parses a URL Query and implements the Params interface with some
@@ -33,5 +34,5 @@ func (qp queryParams) InfoHashes() bittorrent.InfoHashes {
 
 // MarshalZerologObject writes fields into zerolog event
 func (qp queryParams) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("query", str2bytes.BytesToString(qp.Args.QueryString()))
+	e.Str("query", str2bytes.BytesToString(qp.QueryString()))
 }

--- a/middleware/jwt/jwt_test.go
+++ b/middleware/jwt/jwt_test.go
@@ -84,8 +84,8 @@ func init() {
 				KeyID:     base64.RawURLEncoding.EncodeToString(s2.Sum(nil)),
 				Algorithm: jwt.SigningMethodES256.Name,
 				Curve:     privKey.Curve.Params().Name,
-				X:         base64.RawURLEncoding.EncodeToString(privKey.PublicKey.X.Bytes()),
-				Y:         base64.RawURLEncoding.EncodeToString(privKey.PublicKey.Y.Bytes()),
+				X:         base64.RawURLEncoding.EncodeToString(privKey.X.Bytes()),
+				Y:         base64.RawURLEncoding.EncodeToString(privKey.Y.Bytes()),
 			},
 		},
 	}

--- a/pkg/bytepool/bytepool.go
+++ b/pkg/bytepool/bytepool.go
@@ -11,7 +11,7 @@ type BytePool struct {
 // NewBytePool allocates a new BytePool with slices of equal length and capacity.
 func NewBytePool(length int) *BytePool {
 	var bp BytePool
-	bp.Pool.New = func() any {
+	bp.New = func() any {
 		// This avoids allocations for the slice metadata, see:
 		// https://staticcheck.io/docs/checks#SA6002
 		b := make([]byte, length)


### PR DESCRIPTION
* migrate configuration to version 2
* fix new lint warnings
* update lint.yaml to use golangci-lint-action v7 (closes #134)